### PR TITLE
fix(api): skipping dispatching new checks for in_progress checks

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -29143,9 +29143,15 @@ class Api {
             return (new Date(b.created_at).getTime() - new Date(a.created_at).getTime());
         });
         const run = runs[0];
+        // There is a process running the check, skip
+        // dispatching new ones
+        if (run.status !== 'completed') {
+            core.info(`The check is running in progress: ${run.html_url}`);
+            process.exit(0);
+        }
         // Here we re-trigger a new workflow if the previous one
         // is completed and failure.
-        if (run.status === 'completed' && run.conclusion === 'failure') {
+        if (run.conclusion === 'failure') {
             return undefined;
         }
         return run;

--- a/src/api.ts
+++ b/src/api.ts
@@ -276,9 +276,16 @@ export default class Api {
 
     const run = runs[0];
 
+    // There is a process running the check, skip
+    // dispatching new ones
+    if (run.status !== 'completed') {
+      core.info(`The check is running in progress: ${run.html_url}`);
+      process.exit(0);
+    }
+
     // Here we re-trigger a new workflow if the previous one
     // is completed and failure.
-    if (run.status === 'completed' && run.conclusion === 'failure') {
+    if (run.conclusion === 'failure') {
       return undefined;
     }
 


### PR DESCRIPTION
Our checks are re-dispatching on new labels, for example, after completing everything, tagging `mergeongreen` will re-trigger new checks dispatching

ref https://github.com/gear-tech/gear/pull/4007

@reviewer-or-team
